### PR TITLE
Add ADK web entry and refactor Revit agents

### DIFF
--- a/agents/orchestrator_agent/__init__.py
+++ b/agents/orchestrator_agent/__init__.py
@@ -1,0 +1,1 @@
+# This package exposes the orchestrator agent for ADK

--- a/agents/orchestrator_agent/agent.py
+++ b/agents/orchestrator_agent/agent.py
@@ -1,0 +1,5 @@
+"""Entry point for ADK loading."""
+
+from ai.agents.orchestrator_agent import OrchestratorAgent
+
+root_agent = OrchestratorAgent()

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,5 +1,5 @@
 # Usage
 
 1. Install the pyRevit extension and start the AI Design Server from the ribbon.
-2. Run the orchestrator with `python -m ai.cli`.
+2. Run the orchestrator with `adk web agents`.
 3. The agents will process the request and create elements in Revit.


### PR DESCRIPTION
## Summary
- refactor `revit_agent` to use class-based sub agents
- expose orchestrator via `agents/orchestrator_agent` for `adk web`
- update docs to run orchestrator using `adk web`

## Testing
- `pytest -q`
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_b_685e677a022083208492a49b25af7f51