### PR TITLE
Centralize configuration using .env

### DIFF
--- a/ai/agents/revit_agent.py
+++ b/ai/agents/revit_agent.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from typing import AsyncGenerator
 
 from google.adk.agents import BaseAgent, LlmAgent
@@ -15,7 +14,7 @@ from google.adk.tools.mcp_tool.mcp_toolset import (
 # Helper: build the MCP toolset that proxies to revit‑mcp‑python
 # ---------------------------------------------------------------------------
 
-REVIT_MCP_PY_DIR: str = os.getenv("REVIT_MCP_PY_DIR", "./revit-mcp-python")
+from config import REVIT_MCP_PY_DIR
 
 revit_mcp_toolset = MCPToolset(
     connection_params=StdioServerParameters(

--- a/config.py
+++ b/config.py
@@ -1,0 +1,20 @@
+import os
+from dotenv import load_dotenv
+
+# Load environment variables from .env file if present
+load_dotenv()
+
+# General configuration variables for the project
+
+# Directory containing the revit MCP python package
+REVIT_MCP_PY_DIR: str = os.getenv("REVIT_MCP_PY_DIR", "./revit-mcp-python")
+
+# Revit connection information
+REVIT_HOST: str = os.getenv("REVIT_HOST", "localhost")
+REVIT_PORT: int = int(os.getenv("REVIT_PORT", 48884))
+
+# Base URL for Revit MCP API
+BASE_URL: str = os.getenv(
+    "BASE_URL",
+    f"http://{REVIT_HOST}:{REVIT_PORT}/revit_mcp",
+)

--- a/main.py
+++ b/main.py
@@ -3,13 +3,13 @@ from fastmcp import FastMCP, Image, Context
 import base64
 from typing import Optional, Dict, Any, Union
 
+# Load configuration variables
+from config import REVIT_HOST, REVIT_PORT, BASE_URL
+
 # Create a generic MCP server for interacting with Revit
 mcp = FastMCP("Revit MCP Server")
 
-# Configuration
-REVIT_HOST = "localhost"
-REVIT_PORT = 48884  # Default pyRevit Routes port
-BASE_URL = f"http://{REVIT_HOST}:{REVIT_PORT}/revit_mcp"
+# Configuration from config.py
 
 
 async def revit_get(endpoint: str, ctx: Context = None, **kwargs) -> Union[Dict, str]:


### PR DESCRIPTION
## Summary
- centralize configuration variables in `config.py`
- import config values in `main.py` and `revit_agent.py`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_b_685e735a64208320b5eb7055be64984b