### PR TITLE
Fix Windows event loop

### DIFF
--- a/ai/agent.py
+++ b/ai/agent.py
@@ -2,4 +2,18 @@
 
 from ai.agents.orchestrator_agent import OrchestratorAgent
 
+# ---------------------------------------------------------------------------
+# Windows compatibility
+# ---------------------------------------------------------------------------
+# The ADK spawns subprocesses when launching the MCP server. On Windows,
+# the default ``ProactorEventLoop`` does not implement subprocess support,
+# which results in ``NotImplementedError`` when the agents run. Switching to
+# ``WindowsSelectorEventLoopPolicy`` ensures subprocesses work correctly.
+
+import asyncio
+import sys
+
+if sys.platform.startswith("win"):  # pragma: win32
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
 root_agent = OrchestratorAgent()

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -3,3 +3,10 @@
 1. Install the pyRevit extension and start the AI Design Server from the ribbon.
 2. Run the orchestrator with `adk web`.
 3. The agents will process the request and create elements in Revit.
+
+## Windows setup
+
+On Windows, the default event loop does not support subprocesses. If you see a
+`NotImplementedError` related to `subprocess_exec`, upgrade to Python 3.11+ and
+ensure the project sets `asyncio.WindowsSelectorEventLoopPolicy`. This repository
+configures the policy automatically in `ai/agent.py`.


### PR DESCRIPTION
## Summary
- adjust ADK entrypoint to use WindowsSelectorEventLoopPolicy
- document Windows event loop setup

## Testing
- `mkdocs build`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685eab4637a88320a91b3cb804fe8ee3