### PR TITLE
Add curve element creation route and tools

### DIFF
--- a/docs/revit_mcp.md
+++ b/docs/revit_mcp.md
@@ -67,7 +67,7 @@ It contains:
 | `color_splash` | ✅ Implemented | Visualization | Color elements based on parameter values |
 | `execute_revit_code` | ✅ Implemented | Code Execution | Execute IronPython code directly in Revit context |
 | `get_selected_elements` | 🔄 Pending | Selection Management | Get information about currently selected elements |
-| `create_line_based_element` | 🔄 Pending | Element Creation | Create line-based elements (walls, beams, pipes) |
+| `create_line_based_element` | ✅ Implemented | Element Creation | Create line-based elements (walls, beams, pipes) |
 | `create_surface_based_element` | 🔄 Pending | Element Creation | Create surface-based elements (floors, ceilings) |
 | `delete_elements` | 🔄 Pending | Element Management | Delete specified elements from the model |
 | `modify_element` | 🔄 Pending | Element Management | Modify element properties (instance parameters) |

--- a/revit_mcp/curve_tools.py
+++ b/revit_mcp/curve_tools.py
@@ -1,0 +1,100 @@
+# -*- coding: UTF-8 -*-
+"""Curve-based element creation routes for Revit MCP"""
+
+from pyrevit import routes, DB
+import json
+import logging
+
+from .utils import find_family_symbol_safely, create_line_based_element
+
+logger = logging.getLogger(__name__)
+
+
+def register_curve_tools(api):
+    """Register curve-based element routes with the API"""
+
+    @api.route('/create_line_based_element/', methods=['POST'])
+    def create_line_element(doc, request):
+        """Create a line-based family instance between two points."""
+        try:
+            if not doc:
+                return routes.make_response(
+                    data={'error': 'No active Revit document'}, status=503
+                )
+
+            data = json.loads(request.data) if isinstance(request.data, str) else request.data
+            family_name = data.get('family_name')
+            type_name = data.get('type_name')
+            start = data.get('start')
+            end = data.get('end')
+            level_name = data.get('level_name')
+            structural = data.get('structural', False)
+
+            if not family_name or not start or not end:
+                return routes.make_response(
+                    data={'error': 'family_name, start and end are required'},
+                    status=400,
+                )
+
+            symbol = find_family_symbol_safely(doc, family_name, type_name)
+            if not symbol:
+                return routes.make_response(
+                    data={'error': 'Family type not found: {} - {}'.format(family_name, type_name or 'Any')},
+                    status=404,
+                )
+
+            try:
+                start_xyz = DB.XYZ(float(start['x']), float(start['y']), float(start['z']))
+                end_xyz = DB.XYZ(float(end['x']), float(end['y']), float(end['z']))
+            except Exception as coord_err:
+                return routes.make_response(
+                    data={'error': 'Invalid coordinates: {}'.format(coord_err)},
+                    status=400,
+                )
+
+            level = None
+            if level_name:
+                levels = (
+                    DB.FilteredElementCollector(doc)
+                    .OfCategory(DB.BuiltInCategory.OST_Levels)
+                    .WhereElementIsNotElementType()
+                    .ToElements()
+                )
+                for lvl in levels:
+                    try:
+                        if lvl.Name == level_name:
+                            level = lvl
+                            break
+                    except Exception:
+                        continue
+                if level is None:
+                    return routes.make_response(
+                        data={'error': 'Level not found: {}'.format(level_name)},
+                        status=404,
+                    )
+
+            s_type = DB.Structure.StructuralType.Beam if structural else DB.Structure.StructuralType.NonStructural
+
+            instance = create_line_based_element(
+                doc,
+                symbol,
+                start_xyz,
+                end_xyz,
+                level,
+                structural_type=s_type,
+                transaction_name='MCP Create Line Element',
+            )
+
+            return routes.make_response(
+                data={
+                    'status': 'success',
+                    'element_id': instance.Id.IntegerValue,
+                    'family_name': family_name,
+                    'type_name': type_name,
+                }
+            )
+        except Exception as e:
+            logger.error('Failed to create line-based element: %s', str(e))
+            return routes.make_response(data={'error': str(e)}, status=500)
+
+    logger.info('Curve tools routes registered successfully')

--- a/revit_mcp/utils.py
+++ b/revit_mcp/utils.py
@@ -1,4 +1,4 @@
-from pyrevit import DB
+from pyrevit import DB, revit
 import traceback
 import logging
 
@@ -38,3 +38,41 @@ def find_family_symbol_safely(doc, target_family_name, target_type_name=None):
     except Exception as e:
         logger.error("Error finding family symbol: %s", str(e))
         return None
+
+
+def create_line_based_element(doc, family_symbol, start_xyz, end_xyz, level=None, *, structural_type=DB.Structure.StructuralType.NonStructural, transaction_name="Create line-based element"):
+    """Place a curve-based family instance using the Revit API."""
+    if family_symbol is None:
+        raise ValueError("family_symbol is None")
+
+    f_placement = family_symbol.Family.FamilyPlacementType
+    if f_placement not in (
+        DB.FamilyPlacementType.CurveBased,
+        DB.FamilyPlacementType.CurveBasedDetail,
+        DB.FamilyPlacementType.CurveDrivenStructural,
+    ):
+        raise ValueError(
+            "Family is not curve-based.  Placement type: {}".format(f_placement)
+        )
+
+    if not family_symbol.IsActive:
+        family_symbol.Activate()
+        doc.Regenerate()
+
+    curve = DB.Line.CreateBound(start_xyz, end_xyz)
+
+    if level is None and f_placement != DB.FamilyPlacementType.CurveBasedDetail:
+        try:
+            level = doc.ActiveView.GenLevel
+        except AttributeError:
+            level = doc.GetElement(doc.ActiveView.LevelId)
+
+    with revit.Transaction(doc, transaction_name):
+        if f_placement == DB.FamilyPlacementType.CurveBasedDetail:
+            view = doc.ActiveView
+            instance = doc.Create.NewFamilyInstance(curve, family_symbol, view)
+        else:
+            instance = doc.Create.NewFamilyInstance(curve, family_symbol, level, structural_type)
+
+    return instance
+

--- a/startup.py
+++ b/startup.py
@@ -33,6 +33,10 @@ def register_routes():
 
         register_placement_routes(api)
 
+        from revit_mcp.curve_tools import register_curve_tools
+
+        register_curve_tools(api)
+
         from revit_mcp.colors import register_color_routes
 
         register_color_routes(api)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -9,6 +9,7 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     from .family_tools import register_family_tools
     from .model_tools import register_model_tools
     from .colors_tools import register_colors_tools
+    from .curve_tools import register_curve_tools
     from .code_execution_tools import register_code_execution_tools
 
     # Register tools from each module
@@ -17,6 +18,7 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     register_family_tools(mcp_server, revit_get_func, revit_post_func)
     register_model_tools(mcp_server, revit_get_func)
     register_colors_tools(mcp_server, revit_get_func, revit_post_func)
+    register_curve_tools(mcp_server, revit_get_func, revit_post_func)
     register_code_execution_tools(
         mcp_server, revit_get_func, revit_post_func, revit_image_func
     )

--- a/tools/curve_tools.py
+++ b/tools/curve_tools.py
@@ -1,0 +1,32 @@
+"""Curve element creation tools"""
+
+from fastmcp import Context
+
+
+def register_curve_tools(mcp, revit_get, revit_post):
+    """Register curve-related tools"""
+
+    @mcp.tool()
+    async def create_line_based_element(
+        family_name: str,
+        type_name: str = None,
+        start_x: float = 0.0,
+        start_y: float = 0.0,
+        start_z: float = 0.0,
+        end_x: float = 1.0,
+        end_y: float = 0.0,
+        end_z: float = 0.0,
+        level_name: str = None,
+        structural: bool = False,
+        ctx: Context = None,
+    ) -> str:
+        """Create line-based elements like walls or beams"""
+        data = {
+            "family_name": family_name,
+            "type_name": type_name,
+            "start": {"x": start_x, "y": start_y, "z": start_z},
+            "end": {"x": end_x, "y": end_y, "z": end_z},
+            "level_name": level_name,
+            "structural": structural,
+        }
+        return await revit_post("/create_line_based_element/", data, ctx)


### PR DESCRIPTION
## Summary
- implement `create_line_based_element` helper
- add curve route module to create line based elements in Revit
- expose new curve tools in MCP
- register new routes and tools
- document `create_line_based_element` as implemented

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6864328b45ac8320a1b6f435a1f981d5